### PR TITLE
Add instance pattern "cls" for the class method

### DIFF
--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -332,6 +332,7 @@ def make_python_patterns(additional_keywords=[], additional_builtins=[]):
     builtin = r"([^.'\"\\#]\b|^)" + any("builtin", builtinlist) + r"\b"
     comment = any("comment", [r"#[^\n]*"])
     instance = any("instance", [r"\bself\b",
+				r"\bcls\b",
                                 (r"^\s*@([a-zA-Z_][a-zA-Z0-9_]*)"
                                      r"(\.[a-zA-Z_][a-zA-Z0-9_]*)*")])
     number = any("number",


### PR DESCRIPTION
Add a instance pattern "cls" for class method.

The word "cls" usually use in the class method.
I thought we should highlight "cls" just like "self".

For example
```
class Foo:
    @classmethod
    def clsmethod(cls, x):
        pass
```